### PR TITLE
Formatting output and ProForma PTM

### DIFF
--- a/PrimeNovo/denovo/model.py
+++ b/PrimeNovo/denovo/model.py
@@ -777,13 +777,20 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
         # Append data
         with open(file_path,'a') as f:
             for i in range(len(peptides)):
+                sequence = ""
+                for el in peptides[i]:
+                    if len(el) > 1:
+                        sequence += el[0] + '[' + el[1:] + ']'
+                    else:
+                        sequence += el
+
                 # print("label:",batch[2][i], ":" , peptides[i] , "\n")
                 if batch[2][i].replace("$", "").replace("N+0.984", "D").replace("Q+0.984", "E").replace("L","I") == "".join(peptides[i]).replace("$", "").replace("N+0.984", "D").replace("Q+0.984", "E").replace("L","I"):
                     answer_is_correct = "correct"
                 else:
                     answer_is_correct = "incorrect"
                 #each line output this: label (title if label is none), predictions, charge, and confidence score
-                f.write(batch[2][i].replace("\t", " ") + "\t" + "".join(peptides[i]) + "\t" + str(int(batch[1][i][1])) + "\t" + str(float(inferscores[i])) + "\n")
+                f.write(batch[2][i].replace("\t", " ") + "\t" + sequence + "\t" + str(int(batch[1][i][1])) + "\t" + str(float(inferscores[i])) + "\n")
                 
                 #f.write("label: " + batch[2][i] + " prediction : " + "".join(peptides[i]) + "  " + answer_is_correct + "\n")
         


### PR DESCRIPTION
Dear all, when I was trying out this tool, I noticed that the output was relatively hard to parse for other tools. I'm currently working on integrating a bunch of tools in [Rustyms](https://github.com/snijderlab/rustyms/) when I came across this tool. So currently the output of the example file looks like this:
```
label: C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_2327 prediction: YEDM+15.995NNYDPTK charge: 3 score: 0.0001980437955353409
label: C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_3391 prediction: HNHSDSNGTEQVANEHEEQDEEEGQK charge: 4 score: 1.7033361388030244e-08
label: C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_3623 prediction: LSGEVPEEK charge: 2 score: 0.18824972212314606
label: C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_4001 prediction: ALTETDGDMDK charge: 2 score: 0.5424796342849731
label: C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_4306 prediction: ALTETN+0.984GDMDK charge: 2 score: 0.9054621458053589
```
And this is an output of one of our own mgf files converted by [msConvert](https://bio.tools/msconvert):
```
label: 20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.15.15.2 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=15" prediction: LLEEEEELLLEEEEEELLK charge: 2 score: 6.650927265796237e-15
label: 20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.26.26.4 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=26" prediction: YRC+57.021RC+57.021RC+57.021RC+57.021RVC+57.021RC+57.021RC+57.021RC+57.021RC+57.021RYREREC+57.021YHVSTLSSTSTS charge: 4 score: 1.5018822714687173e-15
label: 20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.39.39.4 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=39" prediction: C+57.021YWRWC+57.021WRC+57.021RWRWRWRWRWYRWRWRWLC+57.021TWC+57.021TR charge: 4 score: 1.392839008547902e-16
label: 20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.68.68.4 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=68" prediction: C+57.021RC+57.021EEYRYRYRYRERERYRYRYRERC+57.021YC+57.021YLTVSTSTSK charge: 4 score: 4.763553817521024e-21
label: 20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.77.77.4 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=77" prediction: NQC+57.021YRYRYERC+57.021RYRC+57.021RYRYRYRYRYC+57.021DC+57.021WRVTVSC+57.021ST charge: 4 score: 1.3505266688078956e-16
```
msConvert is a tool that is very populair for converting between various mass spectrometry data formats. That program also uses the ```xxxx:``` format within the mgf title to make sure certain parameters are transferred between file formats. This is exactly the same format as is currently used for the ```label:``` for example. Because this is the same, it is more difficult to parse and get all the correct parameters and columns from the output file.

That is why I propose the following new format, a tab separated value (TSV), which are widely used and very well supported. That would look something like this:
```tsv
label	prediction	charge	score
C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_2980	SVLGRPEDQR	3	0.9857088327407837
C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_3464	NMSDAAEMK	2	0.34145814180374146
C:\Users\xzhang\PeaksProjects\bacillus_PXD004565_D:\data.develop\PXD004565\150710_QEp_PK_Bsub_DG_Br1.raw_SCANS_3819	LQNNSAGYYDTK	2	0.998633086681366
```
And for our dataset, the new output would look like this:
```tsv
label	prediction	charge	score
20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.14.14.2 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=14"	KLLLLKDDDFFDDLLLLLLR	2	9.378444201790792e-13
20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.25.25.4 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=25"	MYWYWYWYWHWRWRWRWRYWRWRWRWYWTC[+57.021]TWT	4	1.1135647019509728e-16
20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.38.38.4 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=38"	C[+57.021]WRWRC[+57.021]RWRWC[+57.021]WRWRWRWRWYRWRWYWLWC[+57.021]GSTS	4	1.6981816350439348e-19
20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.67.67.4 File:"20230408_F1_UM4_Peng0013_SA_EXT00_her_01_tryp.raw", NativeID:"controllerType=0 controllerNumber=1 scan=67"	GWRWRWYWRWRWRWRWRWRYWYWRWYWYWGC[+57.021]STS	4	4.0140123126387384e-19

```
The labels are formatted separately to take out all the tabs (\t) and replacing them by single space. This is to prevent the format from being corrupted if someone includes a tab in their mgf title.

Another thing regarding the parsing are the PTMs. Currently they are formatted like this: ```DANDVC+57.021AHLR```. There is a widely use standard [ProForma](https://doi.org/10.1021/acs.jproteome.1c00771). So while working on the TSV, I also formatted the PTMs, to make them follow the standard. After formatting the PTMs now look like this: ```DANDVC[+57.021]AHLR```.

So what do you think of these changes? I deliberately made separate commits of both these features so you can cherry-pick one if you're interested in merging.