### PR TITLE
Small QOL changes

### DIFF
--- a/PrimeNovo/denovo/model.py
+++ b/PrimeNovo/denovo/model.py
@@ -391,7 +391,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                         
                     else:
                         #ctc_customized_mass_control = CTCMassControl(self.decoder )
-                        print("I am CUDA program")
+                        # print("I am CUDA program")
                         temp = mass_con.knapDecode(logits, mass, self.mass_control_tol)
                         # knapscores = torch.exp(_)
                         # indTemp = torch.tensor(temp)

--- a/PrimeNovo/denovo/model.py
+++ b/PrimeNovo/denovo/model.py
@@ -780,8 +780,10 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                 sequence = ""
                 for el in peptides[i]:
                     if len(el) > 1:
-                        if sequence == "" and (el[0] == '-' or el[0] == '+') :
-                            sequence += '[' + el + ']-'
+                        if el[0] in ('+', '-'):
+                            sequence += '[' + el + ']'
+                        elif el[0].isdigit():
+                            sequence += '[' + el + ']'
                         else:
                             sequence += el[0] + '[' + el[1:] + ']'
                     else:

--- a/pi-PrimeNovo-PTM/PrimeNovo/denovo/model.py
+++ b/pi-PrimeNovo-PTM/PrimeNovo/denovo/model.py
@@ -492,7 +492,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                         
                     else:
                         #ctc_customized_mass_control = CTCMassControl(self.decoder )
-                        print("I am CUDA program")
+                        # print("I am CUDA program")
                         temp = mass_con.knapDecode(logits, mass, self.mass_control_tol)
                         # knapscores = torch.exp(_)
                         # indTemp = torch.tensor(temp)
@@ -900,8 +900,10 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                 sequence = ""
                 for el in peptides[i]:
                     if len(el) > 1:
-                        if sequence == "" and (el[0] == '-' or el[0] == '+') :
-                            sequence += '[' + el + ']-'
+                        if el[0] in ('+', '-'):
+                            sequence += '[' + el + ']'
+                        elif el[0].isdigit():
+                            sequence += '[' + el + ']'
                         else:
                             sequence += el[0] + '[' + el[1:] + ']'
                     else:

--- a/pi-PrimeNovo-PTM/PrimeNovo/denovo/model_PTM.py
+++ b/pi-PrimeNovo-PTM/PrimeNovo/denovo/model_PTM.py
@@ -374,7 +374,7 @@ class Spec2Pep(pl.LightningModule, ModelMixin):
                         
                     else:
                         #ctc_customized_mass_control = CTCMassControl(self.decoder )
-                        print("I am CUDA program")
+                        # print("I am CUDA program")
                         temp = mass_con_PTM.knapDecode(logits, mass)
                         # knapscores = torch.exp(_)
                         # indTemp = torch.tensor(temp)


### PR DESCRIPTION
Hi, a few month ago I also made a PR and @wyattz23 mentioned a potential edge case in #2 that wasn't covered. At that time I couldn't find it in my datasets but now that I'm using this tool more, I kept seeing the potential edge case, namely: 
```
[+43.006-17.027]-+[43.006-17.027]-[17.027]N[+0.984]DN[+0.984]
E+[43.006-17.027]LLLLLLLL-[17.027]LLEEEEEK
EGGA+[43.006-17.027]LLLN[+0.984]
A+[43.006-17.027]LM[+15.995]LH+[43.006-17.027]LLDLK
TN[+0.984]LELEN[+0.984]-[17.027]-[17.027]N[+0.984]
HAEEEEEN[+0.984]-[17.027]N[+0.984]
```

With this PR these peptides will now be formatted as:
```
[+43.006-17.027][+43.006-17.027][-17.027]N[+0.984]DN[+0.984]
E[+43.006-17.027]LLLLLLLL[-17.027]LLEEEEEK
EGGA[+43.006-17.027]LLLN[+0.984]
A[+43.006-17.027]LM[+15.995]LH[+43.006-17.027]LLDLK
TN[+0.984]LELEN[+0.984]-[17.027][-17.027]N[+0.984]
HAEEEEEN[+0.984][-17.027]N[+0.984]
```

I also commented the `print("I am CUDA program")` because they were printing so much, it slowed the prediction a bit.

The only thing left to do is to think about how to format N- and C-terminal modifications because that's not taken into account right now (if we follow ProForma). I also keep seeing a lot of PTMs like this: `[+43.006-17.027][+43.006-17.027][-17.027]AAAAAA`, which is biologically not possible for as far as I know, do you have a guess why the tool is predicting so many PTMs? Let me know what you think of this, I'm curious to hear your thoughts.